### PR TITLE
Fix documentation of --dir-redirects commandline option

### DIFF
--- a/bin/checklink
+++ b/bin/checklink
@@ -869,7 +869,7 @@ Usage: checklink <options> <uris>
 Options:
  -s, --summary              Result summary only.
  -b, --broken               Show only the broken links, not the redirects.
- -e, --directory            Hide directory redirects, for example
+ -e, --dir-redirects        Hide directory redirects, for example
                             http://www.w3.org/TR -> http://www.w3.org/TR/
  -r, --recursive            Check the documents linked from the first one.
  -D, --depth N              Check the documents linked from the first one to

--- a/bin/checklink.pod
+++ b/bin/checklink.pod
@@ -44,7 +44,7 @@ Show result summary only.
 
 Show only the broken links, not the redirects.
 
-=item B<-e, --directory>
+=item B<-e, --dir-redirects>
 
 Hide directory redirects - e.g. L<http://www.w3.org/TR> ->
 L<http://www.w3.org/TR/>.


### PR DESCRIPTION
Was called --directory in documentation.