### PR TITLE
Add instructions to install with App::cpanminus

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ seen at [http://validator.w3.org/checklink](http://validator.w3.org/checklink).
 To install the distribution for command line use:
 
 ```sh
+#if you have cpanminus installed
+cpanm --installdeps .
 perl Makefile.PL
 make
 make test
-make install # as root
+make install # as root unless you are using local::lib
 ```
 
 To install the CGI version, in addition to the above, copy the


### PR DESCRIPTION
Since there is no reference to dependency install, having at least
App:cpanminus in the docs would help a clueless user.

Also added a reference to local::lib, just assuming that the user might
not want to install this systemwide or wants to install somewhere else.