### PR TITLE
Added Dockerfile based on ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu
+
+# Install dependencies required for link-checker distribution installation
+RUN apt-get update && apt-get install -y \
+    cpanminus \
+    make \
+    build-essential \
+    libssl-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Add link-checker user folder
+ENV HOME /home/checklink
+RUN useradd --create-home --home-dir $HOME checklink \
+  && chown -R checklink:checklink $HOME
+
+COPY . /tmp/checklink
+
+RUN cd /tmp/checklink \
+  && cpanm --installdeps . \
+  && cpanm LWP::Protocol::https \
+  && perl Makefile.PL \
+  && make \
+  && make test \
+  && make install
+
+# Clean temporary dist directory
+RUN rm -rf /tmp/checklink
+
+WORKDIR $HOME
+USER checklink


### PR DESCRIPTION
Hi, might be useful to have Docker container to be able to run link-checker on any environment. 
Used `ubuntu`(currently 16.04) image as a base. 
Let me know if that is useful, or anything should be adopted. Could be pushed to docker registry if there is any W3C based.

### To build an image:
```
$ docker build -t link-checker .
```

### To run a container:
```
$ docker run -it --rm link-checker
```
or script directly
```
$ docker run -it --rm link-checker checklink https://www.example.com
```
to write into html file
```
$ docker run -it --rm -v "$PWD":/home/checklink link-checker checklink -H https://www.example.com > report.html
```