### PR TITLE
do not dereference the array if CSP is set

### DIFF
--- a/bin/checklink
+++ b/bin/checklink
@@ -1282,7 +1282,7 @@ EOF
                 }
                 # take optional into account if CSP: block-all-mixed-content is set
                 my $mc_optional = MC_OPTIONAL;
-                if (grep(/^block-all-mixed-content$/, @{$p->{csp}})
+                if (grep(/^block-all-mixed-content$/, $p->{csp})
                     && grep(/^mc_optional$/, @mixedcontent)) {
                     push(@{$links{$canon_uri}{mixedcontent}}, $line_num);
                 }


### PR DESCRIPTION
Linkchecker produces the following error when checking a W3 URL: "Can't use string ("upgrade-insecure-requests") as an ARRAY ref while "strict refs" in use at /usr/local/link-checker/bin/checklink line 1285.".

That PR tries to address the issue.