### PR TITLE
Use valid HTML5

### DIFF
--- a/bin/checklink
+++ b/bin/checklink
@@ -1175,9 +1175,9 @@ EOF
 <div class="settings">
 Settings used:
  <ul>
-  <li><tt><a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Accept</a></tt>: %s</li>
-  <li><tt><a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">Accept-Language</a></tt>: %s</li>
-  <li><tt><a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></tt>: %s</li>
+  <li><code><a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Accept</a></code>: %s</li>
+  <li><code><a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">Accept-Language</a></code>: %s</li>
+  <li><code><a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code>: %s</li>
   <li>Sleeping %d second%s between requests to each server</li>
  </ul>
 </div>
@@ -3396,11 +3396,11 @@ of a document that you would like to check:</label></p>
     <br>
     <label for=\"no_accept_language_$check_num\"><input type=\"checkbox\" id=\"no_accept_language_$check_num\" name=\"no_accept_language\" value=\"on\"",
         $acc,
-        "> Don't send the <tt><a href=\"https://tools.ietf.org/html/rfc7231#section-5.3.5\">Accept-Language</a></tt> header</label>
+        "> Don't send the <code><a href=\"https://tools.ietf.org/html/rfc7231#section-5.3.5\">Accept-Language</a></code> header</label>
     <br>
     <label for=\"no_referer_$check_num\"><input type=\"checkbox\" id=\"no_referer_$check_num\" name=\"no_referer\" value=\"on\"",
         $ref,
-        "> Don't send the <tt><a href=\"https://tools.ietf.org/html/rfc7231#section-5.5.2\">Referer</a></tt> header</label>
+        "> Don't send the <code><a href=\"https://tools.ietf.org/html/rfc7231#section-5.5.2\">Referer</a></code> header</label>
     <br>
     <label title=\"Check linked documents recursively (maximum: ",
         $Opts{Max_Documents},

--- a/bin/checklink
+++ b/bin/checklink
@@ -1410,7 +1410,7 @@ EOF
     # Display results
     if ($Opts{HTML} && !$Opts{Summary_Only}) {
         print("</pre>\n</div>\n");
-        printf("<h2><a name=\"%s\">Results</a></h2>\n", $result_anchor);
+        printf("<h2 id=\"%s\">Results</h2>\n", $result_anchor);
     }
     print "\n" unless $Opts{Quiet};
 

--- a/docs/checklink.html
+++ b/docs/checklink.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>W3C Link Checker Documentation</title>
-    <link rev="made" href="mailto:www-validator@w3.org" />
+    <link rel="author" href="mailto:www-validator@w3.org" />
     <style type="text/css" media="all">@import "linkchecker.css";</style>
   </head>
 
@@ -96,7 +96,7 @@
     </p>
 
     <h3>Access keys</h3>
-      
+
     <p>
       The following access keys are implemented throughout the
       site in an attempt to help users using screen readers.
@@ -117,11 +117,11 @@
       a few other modules which are also available from CPAN.
     </p>
     <h3 id="install-CPAN">Install with the CPAN utility</h3>
-    
+
     <p>If you system has a working installation of Perl, you should be able to install the link checker and its dependencies with a single line from the commandline shell:</p>
     <p><kbd>sudo perl -MCPAN -e 'install W3C::LinkChecker'</kbd> (use without the <kbd>sudo</kbd> command if installing from an administrator account).</p>
     <p>If this is the first time you use the CPAN utility, you may have to answer a few setup questions before the tool downloads, builds and installs the link checker.</p>
-    
+
     <h3 id="install-manual">Install by hand</h3>
 
     <p>If for any reason the technique described above is not working or if you prefer installing each package by hand, follow the instructions below:</p>
@@ -299,9 +299,9 @@ Disallow:
     </address>
     <p class="copyright">
       <a rel="Copyright" href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 1994-2020
-      <a href="https://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a>&reg;
-      (<a href="https://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>,
-      <a href="https://www.ercim.eu/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>,
+      <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a>&reg;
+      (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+      <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
       <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>),
       All Rights Reserved.
       W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,

--- a/docs/checklink.html
+++ b/docs/checklink.html
@@ -3,7 +3,7 @@
   <head>
     <title>W3C Link Checker Documentation</title>
     <link rel="author" href="mailto:www-validator@w3.org" />
-    <style type="text/css" media="all">@import "linkchecker.css";</style>
+    <style media="all">@import "linkchecker.css";</style>
   </head>
 
   <body>
@@ -20,7 +20,7 @@
       <li><a href="#csb">Comments, suggestions and bugs</a></li>
     </ul>
 
-    <h2><a name="about" id="about">About this service</a></h2>
+    <h2 id="about">About this service</h2>
 
     <p>
       In order to check the validity of the technical reports that W3C
@@ -47,7 +47,7 @@
       (development and archived release versions).
     </p>
 
-    <h2><a name="what" id="what">What it does</a></h2>
+    <h2 id="what">What it does</h2>
 
     <p>
       The link checker reads an HTML or XHTML document or a CSS style sheet
@@ -77,7 +77,7 @@
       to the site tested.
     </p>
 
-    <h2><a name="online" id="online">Use it online</a></h2>
+    <h2 id="online">Use it online</h2>
 
     <p>
       There is an
@@ -109,7 +109,7 @@
       <li>Feedback: access key "4" leads to the feedback instructions.</li>
     </ol>
 
-    <h2><a name="install" id="install">Install it locally</a></h2>
+    <h2 id="install">Install it locally</h2>
 
     <p>
       The link checker is written in Perl. It is packaged as a standard
@@ -240,7 +240,7 @@
       for more information.
     </p>
 
-    <h2><a name="bot" id="bot">Robots exclusion</a></h2>
+    <h2 id="bot">Robots exclusion</h2>
 
     <p>
       The link checker honors
@@ -278,7 +278,7 @@ Disallow:
       that honor it; it is not a generic method for access control.
     </p>
 
-    <h2><a name="csb" id="csb">Comments, suggestions and bugs</a></h2>
+    <h2 id="csb">Comments, suggestions and bugs</h2>
 
     <p>
       The current version has proven to be stable. It could however be

--- a/docs/linkchecker.css
+++ b/docs/linkchecker.css
@@ -40,15 +40,15 @@ a:hover, a:active {
     color: #1F2126;
 }
 
-acronym:hover, abbr:hover {
+abbr:hover {
     cursor: help;
 }
-abbr[title], acronym[title], span[title], strong[title] {
+abbr[title], span[title], strong[title] {
     border-bottom: thin dotted;
     cursor: help;
 }
 
-pre, code, tt {
+pre, code {
     font-family: "Bitstream Vera Sans Mono", monospace;
     line-height: 100%;
     white-space: pre;


### PR DESCRIPTION
Although the output and docs were in HTML5, there were a few invalid elements here and there. I replaced these with their closest valid HTML5 equivalent.

CSS was accordingly updated.

Also, the old practice of `<a name="…">` was used in a few places. Besides the fact that the `name` attribute is deprecated (and generates a warning in the HTML validator), it is unnecessary for navigation (as you can just link to any element with an `id` attribute).  I also edited markup in favor of direct `id` attributes as well.