### PR TITLE
disable unprivileged user namespaces to let bwrap set up uid map

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,10 @@ jobs:
         run: python server.py &
       - name: install bubblewrap
         run: sudo apt-get install -y bubblewrap
+      - name: disable unprivileged user namespaces restriction
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: run test suite
         working-directory: test-suite/harness
         run: bwrap --dev-bind / / --ro-bind ../hosts /etc/hosts sh -c "python linktest.py --checker_path ../../link-checker/bin/checklink run"


### PR DESCRIPTION
Now that [ubuntu-latest points to ubuntu 24.04](https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/), [unprivileged user namespaces are disabled by default](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces), which prevents `bwrap` to work as expected.
That PR disables that feature to let the test suite runs as expected.